### PR TITLE
Refactor: use workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b40ccee03b5175c18cde8f37e7d2a33bcef6f8ec8f7cc0d81090d1bb380949c9"
+checksum = "03915af431787e6ffdcc74c645077518c6b6e01f80b761e0fbbfa288536311b3"
 dependencies = [
  "smallvec",
 ]
@@ -2537,7 +2537,7 @@ dependencies = [
  "fp-rpc",
  "fp-rpc-debug",
  "futures 0.3.28",
- "hex-literal 0.3.4",
+ "hex-literal",
  "jsonrpsee",
  "sc-client-api",
  "sc-utils",
@@ -2888,7 +2888,6 @@ dependencies = [
  "hex",
  "parity-scale-codec",
  "serde",
- "serde_json",
  "sp-api",
  "sp-core",
  "sp-io",
@@ -3186,7 +3185,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "frontier-template-runtime",
  "futures 0.3.28",
- "hex-literal 0.4.1",
+ "hex-literal",
  "jsonrpsee",
  "log",
  "pallet-transaction-payment",
@@ -3711,12 +3710,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "hex-literal"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hex-literal"
@@ -5813,7 +5806,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex",
- "hex-literal 0.4.1",
+ "hex-literal",
  "impl-trait-for-tuples",
  "log",
  "pallet-balances",
@@ -9950,7 +9943,7 @@ dependencies = [
  "sp-maybe-compressed-blob",
  "strum",
  "tempfile",
- "toml 0.7.7",
+ "toml 0.7.8",
  "walkdir",
  "wasm-opt",
 ]
@@ -10280,9 +10273,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0a3ab2091e52d7299a39d098e200114a972df0a7724add02a273aa9aada592"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
  "serde",
  "serde_spanned",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "hash-db 0.16.0",
  "log",
@@ -2771,7 +2771,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2950,7 +2950,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2975,7 +2975,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "Inflector",
  "array-bytes 4.2.0",
@@ -3022,7 +3022,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3050,7 +3050,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
@@ -3084,7 +3084,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3100,7 +3100,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -3112,7 +3112,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3122,7 +3122,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "cfg-if",
  "frame-support",
@@ -3141,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3156,7 +3156,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5624,7 +5624,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5640,7 +5640,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5654,7 +5654,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5678,7 +5678,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5707,7 +5707,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5726,7 +5726,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "array-bytes 4.2.0",
  "binary-merkle-tree",
@@ -5951,7 +5951,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5990,7 +5990,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6007,7 +6007,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "1.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6022,7 +6022,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6043,7 +6043,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6058,7 +6058,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6076,7 +6076,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6092,7 +6092,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6108,7 +6108,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6120,7 +6120,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7337,7 +7337,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "log",
  "sp-core",
@@ -7348,7 +7348,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "futures 0.3.28",
  "futures-timer",
@@ -7371,7 +7371,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -7386,7 +7386,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -7405,7 +7405,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7416,7 +7416,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "array-bytes 4.2.0",
  "chrono",
@@ -7456,7 +7456,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "fnv",
  "futures 0.3.28",
@@ -7483,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "hash-db 0.16.0",
  "kvdb",
@@ -7509,7 +7509,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -7534,7 +7534,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -7563,7 +7563,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -7599,7 +7599,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -7612,7 +7612,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "ahash 0.8.3",
  "array-bytes 4.2.0",
@@ -7652,7 +7652,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -7687,7 +7687,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -7710,7 +7710,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "lru 0.8.1",
  "parity-scale-codec",
@@ -7732,7 +7732,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -7744,7 +7744,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7762,7 +7762,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "ansi_term",
  "futures 0.3.28",
@@ -7778,7 +7778,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "array-bytes 4.2.0",
  "parking_lot 0.12.1",
@@ -7792,7 +7792,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "array-bytes 4.2.0",
  "async-channel",
@@ -7837,7 +7837,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "async-channel",
  "cid",
@@ -7858,7 +7858,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -7886,7 +7886,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "ahash 0.8.3",
  "futures 0.3.28",
@@ -7905,7 +7905,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "array-bytes 4.2.0",
  "async-channel",
@@ -7928,7 +7928,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "array-bytes 4.2.0",
  "async-channel",
@@ -7963,7 +7963,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "array-bytes 4.2.0",
  "futures 0.3.28",
@@ -7983,7 +7983,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "array-bytes 4.2.0",
  "bytes",
@@ -8014,7 +8014,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "futures 0.3.28",
  "libp2p-identity",
@@ -8030,7 +8030,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -8039,7 +8039,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "futures 0.3.28",
  "jsonrpsee",
@@ -8070,7 +8070,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -8089,7 +8089,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -8104,7 +8104,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "array-bytes 4.2.0",
  "futures 0.3.28",
@@ -8130,7 +8130,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "async-trait",
  "directories",
@@ -8196,7 +8196,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8207,7 +8207,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.1.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "clap",
  "fs4",
@@ -8223,7 +8223,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "futures 0.3.28",
  "libc",
@@ -8242,7 +8242,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "chrono",
  "futures 0.3.28",
@@ -8261,7 +8261,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "ansi_term",
  "atty",
@@ -8292,7 +8292,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -8303,7 +8303,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -8330,7 +8330,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -8344,7 +8344,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "async-channel",
  "futures 0.3.28",
@@ -8823,7 +8823,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "hash-db 0.16.0",
  "log",
@@ -8843,7 +8843,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "Inflector",
  "blake2",
@@ -8857,7 +8857,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "7.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "6.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -8884,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8896,7 +8896,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "futures 0.3.28",
  "log",
@@ -8914,7 +8914,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -8929,7 +8929,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8947,7 +8947,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8968,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -8987,7 +8987,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -9005,7 +9005,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9017,7 +9017,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "array-bytes 4.2.0",
  "bitflags 1.3.2",
@@ -9061,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -9075,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9086,7 +9086,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9105,7 +9105,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9116,7 +9116,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -9131,7 +9131,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "bytes",
  "ed25519 1.5.3",
@@ -9157,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "7.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -9168,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "futures 0.3.28",
  "parity-scale-codec",
@@ -9182,7 +9182,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -9191,7 +9191,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.1.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -9202,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -9230,7 +9230,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -9240,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -9250,7 +9250,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "7.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -9272,7 +9272,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -9290,7 +9290,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -9302,7 +9302,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9316,7 +9316,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9329,7 +9329,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "hash-db 0.16.0",
  "log",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9367,12 +9367,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9385,7 +9385,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -9400,7 +9400,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -9412,7 +9412,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -9421,7 +9421,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "async-trait",
  "log",
@@ -9437,7 +9437,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "ahash 0.8.3",
  "hash-db 0.16.0",
@@ -9460,7 +9460,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9477,7 +9477,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -9488,7 +9488,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9801,7 +9801,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "platforms 2.0.0",
 ]
@@ -9809,7 +9809,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.28",
@@ -9828,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "hyper",
  "log",
@@ -9840,7 +9840,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -9866,7 +9866,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "array-bytes 6.1.0",
  "frame-executive",
@@ -9914,7 +9914,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "futures 0.3.28",
  "parity-scale-codec",
@@ -9934,7 +9934,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#e955a318e60ac785b0b509882f56af0c44f636c3"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
 dependencies = [
  "ansi_term",
  "build-helper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "hash-db 0.16.0",
  "log",
@@ -2771,7 +2771,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2950,7 +2950,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2975,7 +2975,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "Inflector",
  "array-bytes 4.2.0",
@@ -3022,7 +3022,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3050,7 +3050,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
@@ -3084,7 +3084,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3100,7 +3100,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -3112,7 +3112,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3122,7 +3122,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "cfg-if",
  "frame-support",
@@ -3141,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3156,7 +3156,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5624,7 +5624,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5640,7 +5640,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5654,7 +5654,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5678,7 +5678,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5707,7 +5707,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5726,7 +5726,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "array-bytes 4.2.0",
  "binary-merkle-tree",
@@ -5951,7 +5951,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5990,7 +5990,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6007,7 +6007,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "1.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6022,7 +6022,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6043,7 +6043,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6058,7 +6058,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6076,7 +6076,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6092,7 +6092,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6108,7 +6108,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6120,7 +6120,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7337,7 +7337,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "log",
  "sp-core",
@@ -7348,7 +7348,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "futures 0.3.28",
  "futures-timer",
@@ -7371,7 +7371,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -7386,7 +7386,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -7405,7 +7405,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7416,7 +7416,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "array-bytes 4.2.0",
  "chrono",
@@ -7456,7 +7456,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "fnv",
  "futures 0.3.28",
@@ -7483,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "hash-db 0.16.0",
  "kvdb",
@@ -7509,7 +7509,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -7534,7 +7534,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -7563,7 +7563,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -7599,7 +7599,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -7612,7 +7612,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "ahash 0.8.3",
  "array-bytes 4.2.0",
@@ -7652,7 +7652,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -7687,7 +7687,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -7710,7 +7710,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "lru 0.8.1",
  "parity-scale-codec",
@@ -7732,7 +7732,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -7744,7 +7744,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7762,7 +7762,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "ansi_term",
  "futures 0.3.28",
@@ -7778,7 +7778,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "array-bytes 4.2.0",
  "parking_lot 0.12.1",
@@ -7792,7 +7792,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "array-bytes 4.2.0",
  "async-channel",
@@ -7837,7 +7837,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "async-channel",
  "cid",
@@ -7858,7 +7858,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -7886,7 +7886,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "ahash 0.8.3",
  "futures 0.3.28",
@@ -7905,7 +7905,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "array-bytes 4.2.0",
  "async-channel",
@@ -7928,7 +7928,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "array-bytes 4.2.0",
  "async-channel",
@@ -7963,7 +7963,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "array-bytes 4.2.0",
  "futures 0.3.28",
@@ -7983,7 +7983,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "array-bytes 4.2.0",
  "bytes",
@@ -8014,7 +8014,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "futures 0.3.28",
  "libp2p-identity",
@@ -8030,7 +8030,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -8039,7 +8039,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "futures 0.3.28",
  "jsonrpsee",
@@ -8070,7 +8070,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -8089,7 +8089,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -8104,7 +8104,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "array-bytes 4.2.0",
  "futures 0.3.28",
@@ -8130,7 +8130,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "async-trait",
  "directories",
@@ -8196,7 +8196,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8207,7 +8207,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.1.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "clap",
  "fs4",
@@ -8223,7 +8223,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "futures 0.3.28",
  "libc",
@@ -8242,7 +8242,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "chrono",
  "futures 0.3.28",
@@ -8261,7 +8261,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "ansi_term",
  "atty",
@@ -8292,7 +8292,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -8303,7 +8303,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -8330,7 +8330,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -8344,7 +8344,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "async-channel",
  "futures 0.3.28",
@@ -8823,7 +8823,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "hash-db 0.16.0",
  "log",
@@ -8843,7 +8843,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "Inflector",
  "blake2",
@@ -8857,7 +8857,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "7.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "6.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -8884,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8896,7 +8896,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "futures 0.3.28",
  "log",
@@ -8914,7 +8914,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -8929,7 +8929,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8947,7 +8947,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8968,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -8987,7 +8987,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -9005,7 +9005,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9017,7 +9017,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "array-bytes 4.2.0",
  "bitflags 1.3.2",
@@ -9061,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -9075,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9086,7 +9086,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9105,7 +9105,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9116,7 +9116,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -9131,7 +9131,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "bytes",
  "ed25519 1.5.3",
@@ -9157,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "7.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -9168,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "futures 0.3.28",
  "parity-scale-codec",
@@ -9182,7 +9182,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -9191,7 +9191,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.1.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -9202,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -9230,7 +9230,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -9240,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -9250,7 +9250,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "7.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -9272,7 +9272,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -9290,7 +9290,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -9302,7 +9302,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9316,7 +9316,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9329,7 +9329,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "hash-db 0.16.0",
  "log",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9367,12 +9367,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9385,7 +9385,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -9400,7 +9400,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -9412,7 +9412,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -9421,7 +9421,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "async-trait",
  "log",
@@ -9437,7 +9437,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "ahash 0.8.3",
  "hash-db 0.16.0",
@@ -9460,7 +9460,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9477,7 +9477,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -9488,7 +9488,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9801,7 +9801,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "platforms 2.0.0",
 ]
@@ -9809,7 +9809,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.28",
@@ -9828,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "hyper",
  "log",
@@ -9840,7 +9840,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -9866,7 +9866,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "array-bytes 6.1.0",
  "frame-executive",
@@ -9914,7 +9914,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "futures 0.3.28",
  "parity-scale-codec",
@@ -9934,7 +9934,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43-minor-update#579071f111e4752241d313b5066734e10a3dbac4"
+source = "git+https://github.com/bifrost-platform/bifrost-substrate?branch=bifrost-polkadot-v0.9.43#ebe009c20231a8f1bd11a256190fbbcb4523f471"
 dependencies = [
  "ansi_term",
  "build-helper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,81 +84,81 @@ thiserror = "1.0"
 tokio = "1.13"
 tracing = "0.1.34"
 # Substrate Client
-sc-basic-authorship = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-block-builder = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-cli = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-client-db = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-consensus = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-consensus-aura = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-consensus-grandpa = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-consensus-manual-seal = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-executor = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-finality-grandpa = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-keystore = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-network = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-network-common = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-rpc = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-rpc-api = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-service = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sc-utils = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-basic-authorship = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-block-builder = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-cli = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-client-db = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-consensus = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-consensus-aura = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-consensus-grandpa = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-consensus-manual-seal = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-executor = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-finality-grandpa = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-keystore = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-network = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-network-common = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-rpc = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-rpc-api = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-service = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-utils = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
 # Substrate Primitive
-sp-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sp-consensus = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sp-consensus-aura = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-sp-consensus-grandpa = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-sp-core = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-sp-database = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sp-externalities = { version = "0.13.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-sp-finality-grandpa = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-sp-inherents = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-sp-io = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-sp-keyring = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-sp-offchain = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-sp-runtime = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-sp-runtime-interface = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-sp-session = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-sp-state-machine = { version = "0.13.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-sp-std = { version = "5.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-sp-storage = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-sp-trie = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-sp-version = { version = "5.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sp-consensus = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sp-consensus-aura = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-consensus-grandpa = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-core = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-database = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sp-externalities = { version = "0.13.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-finality-grandpa = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-inherents = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-io = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-keyring = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sp-offchain = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-runtime = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-runtime-interface = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-session = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-state-machine = { version = "0.13.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-std = { version = "5.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-storage = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-trie = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-version = { version = "5.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
 # Substrate FRAME
-frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-frame-executive = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-frame-support = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-frame-system = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-frame-system-benchmarking = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-frame-system-rpc-runtime-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-pallet-aura = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-pallet-balances = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-pallet-grandpa = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-pallet-sudo = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-pallet-transaction-payment = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
-pallet-utility = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+frame-executive = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+frame-support = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+frame-system = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+frame-system-benchmarking = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+frame-system-rpc-runtime-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+pallet-aura = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+pallet-balances = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+pallet-grandpa = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+pallet-sudo = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+pallet-transaction-payment = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+pallet-utility = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
 parity-scale-codec = { version = "3.2.2", default-features = false, features = [
 	"derive",
 ] }
 # Substrate Utility
-frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-substrate-prometheus-endpoint = { git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-substrate-test-runtime-client = { version = "2.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+substrate-prometheus-endpoint = { git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+substrate-test-runtime-client = { version = "2.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
 # Frontier Client
 fc-cli = { version = "1.0.0-dev", path = "client/cli", default-features = false }
 fc-consensus = { version = "2.0.0-dev", path = "client/consensus" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,81 +84,81 @@ thiserror = "1.0"
 tokio = "1.13"
 tracing = "0.1.34"
 # Substrate Client
-sc-basic-authorship = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-block-builder = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-cli = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-client-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-client-db = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-consensus = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-consensus-aura = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-consensus-grandpa = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-consensus-manual-seal = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-executor = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-finality-grandpa = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-keystore = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-network = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-network-common = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-rpc = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-rpc-api = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-service = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sc-utils = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+sc-basic-authorship = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-block-builder = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-chain-spec = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-cli = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-client-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-client-db = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-consensus = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-consensus-aura = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-consensus-grandpa = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-consensus-manual-seal = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-executor = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-finality-grandpa = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-keystore = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-network = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-network-common = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-network-sync = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-rpc = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-rpc-api = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-service = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-telemetry = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-transaction-pool-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sc-utils = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
 # Substrate Primitive
-sp-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sp-consensus = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sp-consensus-aura = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-sp-consensus-grandpa = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-sp-core = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-sp-database = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sp-externalities = { version = "0.13.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-sp-finality-grandpa = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-sp-inherents = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-sp-io = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-sp-keyring = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-sp-offchain = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-sp-runtime = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-sp-runtime-interface = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-sp-session = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-sp-state-machine = { version = "0.13.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-sp-std = { version = "5.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-sp-storage = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-sp-trie = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-sp-version = { version = "5.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+sp-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-block-builder = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-blockchain = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sp-consensus = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sp-consensus-aura = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-consensus-grandpa = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-core = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-database = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sp-externalities = { version = "0.13.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-finality-grandpa = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-inherents = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-io = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-keyring = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+sp-offchain = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-runtime = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-runtime-interface = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-session = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-state-machine = { version = "0.13.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-std = { version = "5.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-storage = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-timestamp = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-transaction-pool = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-trie = { version = "7.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+sp-version = { version = "5.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
 # Substrate FRAME
-frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-frame-executive = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-frame-support = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-frame-system = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-frame-system-benchmarking = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-frame-system-rpc-runtime-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-pallet-aura = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-pallet-balances = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-pallet-grandpa = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-pallet-sudo = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-pallet-transaction-payment = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
-pallet-utility = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update", default-features = false }
+frame-benchmarking = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+frame-executive = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+frame-support = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+frame-system = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+frame-system-benchmarking = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+frame-system-rpc-runtime-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+pallet-aura = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+pallet-balances = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+pallet-grandpa = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+pallet-sudo = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+pallet-timestamp = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+pallet-transaction-payment = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+pallet-utility = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
 parity-scale-codec = { version = "3.2.2", default-features = false, features = [
 	"derive",
 ] }
 # Substrate Utility
-frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-substrate-prometheus-endpoint = { git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-substrate-test-runtime-client = { version = "2.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
-substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43-minor-update" }
+frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+substrate-build-script-utils = { version = "3.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+substrate-frame-rpc-system = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+substrate-prometheus-endpoint = { git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+substrate-test-runtime-client = { version = "2.0.0", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
+substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
 # Frontier Client
 fc-cli = { version = "1.0.0-dev", path = "client/cli", default-features = false }
 fc-consensus = { version = "2.0.0-dev", path = "client/consensus" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,11 +76,13 @@ parking_lot = "0.12.1"
 rlp = { version = "0.5", default-features = false }
 scale-codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3.1", default-features = false, features = ["derive"] }
-serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
+serde = { version = "1.0.101", default-features = false, features = ["derive", "alloc"] }
 serde_json = "1.0"
+sha3 = "0.10"
 sqlx = { version = "0.7.0-alpha.3", default-features = false, features = ["macros"] }
 thiserror = "1.0"
 tokio = "1.13"
+tracing = "0.1.34"
 # Substrate Client
 sc-basic-authorship = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
 sc-block-builder = { version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
@@ -146,6 +148,9 @@ pallet-transaction-payment = { version = "4.0.0-dev", git = "https://github.com/
 pallet-transaction-payment-rpc = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
 pallet-transaction-payment-rpc-runtime-api = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
 pallet-utility = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43", default-features = false }
+parity-scale-codec = { version = "3.2.2", default-features = false, features = [
+	"derive",
+] }
 # Substrate Utility
 frame-benchmarking-cli = { version = "4.0.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.10.0-dev", git = "https://github.com/bifrost-platform/bifrost-substrate", branch = "bifrost-polkadot-v0.9.43" }

--- a/client/bifrost/evm-tracing/Cargo.toml
+++ b/client/bifrost/evm-tracing/Cargo.toml
@@ -2,20 +2,20 @@
 name = "fc-evm-tracing"
 authors = ["bifrost-platform"]
 edition = "2021"
-homepage = "https://thebifrost.io"
+homepage = "https://www.bifrostnetwork.com"
 license = "Apache-2.0"
 repository = "https://github.com/bifrost-platform/bifrost-frontier"
 version = "0.1.0"
 
 [dependencies]
-ethereum-types = { version = "0.14", features = ["std"] }
-hex = { version = "0.4.3", features = ["serde"] }
-serde = { version = "1.0.101", features = ["derive", "std"] }
-serde_json = { version = "1.0" }
+ethereum-types = { workspace = true, features = ["std"] }
+hex = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features = ["derive", "std"] }
+serde_json = { workspace = true }
 
 fp-rpc-debug = { workspace = true, features = ["std"] }
 fp-rpc-evm-tracing-events = { workspace = true, features = ["std"] }
 
 # Substrate
-codec = { package = "parity-scale-codec", version = "3.2.2", features = ["std"] }
+parity-scale-codec = { workspace = true, features = ["std"] }
 sp-std = { workspace = true, features = ["std"] }

--- a/client/bifrost/evm-tracing/src/formatters/blockscout.rs
+++ b/client/bifrost/evm-tracing/src/formatters/blockscout.rs
@@ -6,8 +6,8 @@ use crate::{
 		CallResult, CallType, CreateResult,
 	},
 };
-use codec::{Decode, Encode};
 use ethereum_types::{H160, U256};
+use parity_scale_codec::{Decode, Encode};
 use serde::Serialize;
 
 pub struct Formatter;

--- a/client/bifrost/evm-tracing/src/formatters/call_tracer.rs
+++ b/client/bifrost/evm-tracing/src/formatters/call_tracer.rs
@@ -9,8 +9,8 @@ use crate::listeners::call_list::Listener;
 use crate::types::serialization::*;
 use serde::Serialize;
 
-use codec::{Decode, Encode};
 use ethereum_types::{H160, U256};
+use parity_scale_codec::{Decode, Encode};
 use sp_std::{cmp::Ordering, vec::Vec};
 
 pub struct Formatter;

--- a/client/bifrost/evm-tracing/src/types/block.rs
+++ b/client/bifrost/evm-tracing/src/types/block.rs
@@ -3,8 +3,8 @@
 use super::serialization::*;
 use serde::Serialize;
 
-use codec::{Decode, Encode};
 use ethereum_types::{H160, H256, U256};
+use parity_scale_codec::{Decode, Encode};
 use sp_std::vec::Vec;
 
 #[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, Serialize)]

--- a/client/bifrost/evm-tracing/src/types/mod.rs
+++ b/client/bifrost/evm-tracing/src/types/mod.rs
@@ -2,8 +2,8 @@
 
 extern crate alloc;
 
-use codec::{Decode, Encode};
 use ethereum_types::{H160, H256};
+use parity_scale_codec::{Decode, Encode};
 use sp_std::vec::Vec;
 
 pub mod block;

--- a/client/bifrost/evm-tracing/src/types/single.rs
+++ b/client/bifrost/evm-tracing/src/types/single.rs
@@ -6,8 +6,8 @@
 use super::serialization::*;
 use serde::Serialize;
 
-use codec::{Decode, Encode};
 use ethereum_types::{H256, U256};
+use parity_scale_codec::{Decode, Encode};
 use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
 #[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, Serialize)]

--- a/client/bifrost/rpc-core/debug/Cargo.toml
+++ b/client/bifrost/rpc-core/debug/Cargo.toml
@@ -2,18 +2,21 @@
 name = "fc-rpc-core-debug"
 authors = ["bifrost-platform"]
 edition = "2021"
-homepage = "https://thebifrost.io"
+homepage = "https://www.bifrostnetwork.com"
 license = "Apache-2.0"
 repository = "https://github.com/bifrost-platform/bifrost-frontier"
 version = "0.1.0"
 
 [dependencies]
-ethereum-types = { version = "0.14", features = ["std"] }
+ethereum-types = { workspace = true, features = ["std"] }
+futures = { workspace = true, features = ["compat"] }
+jsonrpsee = { workspace = true, features = ["macros", "server"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+
+# Substrate
+sp-core = { workspace = true, features = ["std"] }
+
+# Frontier
 fc-evm-tracing = { workspace = true }
 fc-rpc-core-types = { workspace = true }
-futures = { version = "0.3.21", features = ["compat"] }
-jsonrpsee = { version = "0.16.2", default-features = false, features = ["macros", "server"] }
-serde = { version = "1.0.101", features = ["derive"] }
-serde_json = { version = "1.0" }
-
-sp-core = { workspace = true, features = ["std"] }

--- a/client/bifrost/rpc-core/trace/Cargo.toml
+++ b/client/bifrost/rpc-core/trace/Cargo.toml
@@ -1,17 +1,19 @@
 [package]
 name = "fc-rpc-core-trace"
-authors = [ "bifrost-platform" ]
+authors = ["bifrost-platform"]
 edition = "2021"
-homepage = "https://thebifrost.io"
+homepage = "https://www.bifrostnetwork.com"
 license = "Apache-2.0"
 repository = "https://github.com/bifrost-platform/bifrost-frontier"
 version = "0.6.0"
 
 [dependencies]
-ethereum-types = "0.14"
-futures = { version = "0.3.1", features = [ "compat" ] }
-jsonrpsee = { version = "0.16.2", default-features = false, features = [ "macros", "server" ] }
+ethereum-types = { workspace = true, features = ["std"] }
+futures = { workspace = true, features = ["compat"] }
+jsonrpsee = { workspace = true, features = ["macros", "server"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+
+# Frontier
 fc-evm-tracing = { workspace = true }
 fc-rpc-core-types = { workspace = true }
-serde = { version = "1.0", features = [ "derive" ] }
-serde_json = "1.0"

--- a/client/bifrost/rpc-core/txpool/Cargo.toml
+++ b/client/bifrost/rpc-core/txpool/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
 name = "fc-rpc-core-txpool"
-authors = [ "bifrost-platform" ]
+authors = ["bifrost-platform"]
 edition = "2021"
-homepage = "https://thebifrost.io"
+homepage = "https://www.bifrostnetwork.com"
 license = "Apache-2.0"
 repository = "https://github.com/bifrost-platform/bifrost-frontier"
 version = "0.6.0"
 
 [dependencies]
-ethereum = { version = "0.14.0", default-features = false, features = [ "with-codec" ] }
-ethereum-types = "0.14"
-jsonrpsee = { version = "0.16.2", default-features = false, features = [ "macros", "server" ] }
-serde = { version = "1.0", features = [ "derive" ] }
-serde_json = "1.0"
+ethereum = { workspace = true, features = ["std", "with-codec"] }
+ethereum-types = { workspace = true, features = ["std"] }
+jsonrpsee = { workspace = true, features = ["macros", "server"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 
+# Frontier
 fc-rpc-core = { workspace = true }

--- a/client/bifrost/rpc-core/types/Cargo.toml
+++ b/client/bifrost/rpc-core/types/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "fc-rpc-core-types"
-authors = [ "bifrost-platform" ]
+authors = ["bifrost-platform"]
 edition = "2021"
-homepage = "https://thebifrost.io"
+homepage = "https://www.bifrostnetwork.com"
 license = "Apache-2.0"
 repository = "https://github.com/bifrost-platform/bifrost-frontier"
 version = "0.1.0"
 
 [dependencies]
-ethereum-types = "0.14"
-serde = { version = "1.0", features = [ "derive" ] }
-serde_json = "1.0"
+ethereum-types = { workspace = true, features = ["std"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }

--- a/client/bifrost/rpc/debug/Cargo.toml
+++ b/client/bifrost/rpc/debug/Cargo.toml
@@ -2,18 +2,18 @@
 name = "fc-rpc-debug"
 authors = ["bifrost-platform"]
 edition = "2021"
-homepage = "https://thebifrost.io"
+homepage = "https://www.bifrostnetwork.com"
 license = "Apache-2.0"
 repository = "https://github.com/bifrost-platform/bifrost-frontier"
 version = "0.1.0"
 
 [dependencies]
-futures = { version = "0.3.21", features = ["compat"] }
-hex-literal = "0.3.4"
-jsonrpsee = { version = "0.16.2", features = ["macros", "server"] }
-tokio = { version = "1.13", features = ["sync", "time"] }
+futures = { workspace = true, features = ["compat"] }
+hex-literal = { workspace = true }
+jsonrpsee = { workspace = true, features = ["macros", "server"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 
-# BIFROST
+# Bifrost
 fc-evm-tracing = { workspace = true }
 fc-rpc-core-debug = { workspace = true }
 fc-rpc-core-types = { workspace = true }
@@ -30,8 +30,8 @@ sp-io = { workspace = true, features = ["std"] }
 sp-runtime = { workspace = true, features = ["std"] }
 
 # Frontier
-ethereum = { version = "0.14.0", default-features = false, features = ["std", "with-codec"] }
-ethereum-types = { version = "0.14", features = ["std"] }
+ethereum = { workspace = true, features = ["std", "with-codec"] }
+ethereum-types = { workspace = true, features = ["std"] }
 fc-consensus = { workspace = true }
 fc-db = { workspace = true }
 fc-rpc = { workspace = true, features = ["rpc-binary-search-estimate"] }

--- a/client/bifrost/rpc/trace/Cargo.toml
+++ b/client/bifrost/rpc/trace/Cargo.toml
@@ -2,22 +2,21 @@
 name = "fc-rpc-trace"
 authors = ["bifrost-platform"]
 edition = "2021"
-homepage = "https://thebifrost.io"
+homepage = "https://www.bifrostnetwork.com"
 license = "Apache-2.0"
 repository = "https://github.com/bifrost-platform/bifrost-frontier"
 version = "0.6.0"
 
 [dependencies]
-ethereum = { version = "0.14.0", features = ["with-codec"] }
-ethereum-types = "0.14"
-futures = { version = "0.3" }
-jsonrpsee = { version = "0.16.2", default-features = false, features = ["macros", "server"] }
+ethereum = { workspace = true, features = ["with-codec"] }
+ethereum-types = { workspace = true }
+futures = { workspace = true }
+jsonrpsee = { workspace = true, features = ["macros", "server"] }
 log = { workspace = true }
-serde = { version = "1.0", features = ["derive"] }
-sha3 = "0.10"
-substrate-prometheus-endpoint = { workspace = true }
-tokio = { version = "1.10", features = ["sync", "time"] }
-tracing = "0.1.34"
+serde = { workspace = true, features = ["derive"] }
+sha3 = { workspace = true }
+tokio = { workspace = true, features = ["sync", "time"] }
+tracing = { workspace = true }
 
 fc-evm-tracing = { workspace = true }
 fc-rpc-core-trace = { workspace = true }
@@ -35,6 +34,7 @@ sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 sp-transaction-pool = { workspace = true }
+substrate-prometheus-endpoint = { workspace = true }
 
 # Frontier
 fc-consensus = { workspace = true }

--- a/client/bifrost/rpc/txpool/Cargo.toml
+++ b/client/bifrost/rpc/txpool/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "fc-rpc-txpool"
-authors = [ "bifrost-platform" ]
+authors = ["bifrost-platform"]
 edition = "2021"
-homepage = "https://thebifrost.io"
+homepage = "https://www.bifrostnetwork.com"
 license = "Apache-2.0"
 repository = "https://github.com/bifrost-platform/bifrost-frontier"
 version = "0.6.0"
 
 [dependencies]
-jsonrpsee = { version = "0.16.2", default-features = false, features = [ "macros", "server" ] }
-rlp = "0.5"
-serde = { version = "1.0", features = [ "derive" ] }
-sha3 = "0.10"
+jsonrpsee = { workspace = true, features = ["macros", "server"] }
+rlp = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+sha3 = { workspace = true }
 
 fc-rpc-core-txpool = { workspace = true }
-fp-rpc-txpool = { workspace = true }
+fp-rpc-txpool = { workspace = true, features = ["std"] }
 
 # Substrate
 frame-system = { workspace = true }
@@ -27,5 +27,5 @@ sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 
 # Frontier
-ethereum-types = "0.14"
-fc-rpc = { workspace = true, features = [ "rpc-binary-search-estimate" ] }
+ethereum-types = { workspace = true, features = ["std"] }
+fc-rpc = { workspace = true, features = ["rpc-binary-search-estimate"] }

--- a/primitives/bifrost/ext/Cargo.toml
+++ b/primitives/bifrost/ext/Cargo.toml
@@ -1,28 +1,28 @@
 [package]
 name = "fp-ext"
-authors = [ "bifrost-platform" ]
+authors = ["bifrost-platform"]
 edition = "2021"
-homepage = "https://thebifrost.io"
+homepage = "https://www.bifrostnetwork.com"
 license = "Apache-2.0"
 repository = "https://github.com/bifrost-platform/bifrost-frontier"
 version = "0.1.0"
 
 [dependencies]
-ethereum-types = { version = "0.14", default-features = false }
+ethereum-types = { workspace = true }
 
-# BIFROST
+# Frontier
 fp-rpc-evm-tracing-events = { workspace = true }
 
 # Substrate
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
+parity-scale-codec = { workspace = true }
 sp-externalities = { workspace = true }
 sp-runtime-interface = { workspace = true }
 sp-std = { workspace = true }
 
 [features]
-default = [ "std" ]
+default = ["std"]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"ethereum-types/std",
 	"fp-rpc-evm-tracing-events/std",
 	"sp-externalities/std",

--- a/primitives/bifrost/ext/src/lib.rs
+++ b/primitives/bifrost/ext/src/lib.rs
@@ -9,7 +9,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 use sp_runtime_interface::runtime_interface;
 
-use codec::Decode;
+use parity_scale_codec::Decode;
 use sp_std::vec::Vec;
 
 use fp_rpc_evm_tracing_events::{Event, EvmEvent, GasometerEvent, RuntimeEvent, StepEventFilter};

--- a/primitives/bifrost/rpc/debug/Cargo.toml
+++ b/primitives/bifrost/rpc/debug/Cargo.toml
@@ -2,21 +2,20 @@
 name = "fp-rpc-debug"
 authors = ["bifrost-platform"]
 edition = "2021"
-homepage = "https://thebifrost.io"
+homepage = "https://www.bifrostnetwork.com"
 license = "Apache-2.0"
 repository = "https://github.com/bifrost-platform/bifrost-frontier"
 version = "0.1.0"
 
 [dependencies]
-environmental = { version = "1.1.2", default-features = false }
+environmental = { workspace = true }
 ethereum = { workspace = true }
 ethereum-types = { workspace = true }
-hex = { version = "0.4.3", optional = true, features = ["serde"] }
-serde = { version = "1.0.101", optional = true, features = ["derive"] }
-serde_json = { version = "1.0", optional = true }
+hex = { workspace = true, optional = true, features = ["serde"] }
+serde = { workspace = true, optional = true, features = ["derive"] }
 
 # Substrate
-codec = { package = "parity-scale-codec", version = "3.2.2", default-features = false }
+parity-scale-codec = { workspace = true }
 sp-api = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
@@ -26,13 +25,12 @@ sp-std = { workspace = true }
 [features]
 default = ["std"]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"environmental/std",
 	"ethereum-types/std",
 	"ethereum/std",
 	"hex",
 	"serde",
-	"serde_json",
 	"sp-api/std",
 	"sp-core/std",
 	"sp-io/std",

--- a/primitives/bifrost/rpc/debug/src/lib.rs
+++ b/primitives/bifrost/rpc/debug/src/lib.rs
@@ -1,8 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode};
 use ethereum::{TransactionV0 as LegacyTransaction, TransactionV2 as Transaction};
 use ethereum_types::H256;
+use parity_scale_codec::{Decode, Encode};
 use sp_std::vec::Vec;
 
 sp_api::decl_runtime_apis! {

--- a/primitives/bifrost/rpc/evm-tracing-events/Cargo.toml
+++ b/primitives/bifrost/rpc/evm-tracing-events/Cargo.toml
@@ -2,29 +2,29 @@
 name = "fp-rpc-evm-tracing-events"
 authors = ["bifrost-platform"]
 edition = "2021"
-homepage = "https://thebifrost.io"
+homepage = "https://www.bifrostnetwork.com"
 license = "Apache-2.0"
 repository = "https://github.com/bifrost-platform/bifrost-frontier"
 version = "0.1.0"
 
 [dependencies]
-environmental = { version = "1.1.2", default-features = false }
+environmental = { workspace = true }
 
 # Substrate
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
+parity-scale-codec = { workspace = true }
 sp-runtime-interface = { workspace = true }
 
 # Ethereum
-ethereum = { workspace = true }
+ethereum = { workspace = true, features = ["with-codec"] }
 ethereum-types = { workspace = true }
-evm = { workspace = true }
+evm = { workspace = true, features = ["with-codec"] }
 evm-gasometer = { workspace = true }
 evm-runtime = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"environmental/std",
 	"ethereum-types/std",
 	"ethereum/std",

--- a/primitives/bifrost/rpc/evm-tracing-events/src/evm.rs
+++ b/primitives/bifrost/rpc/evm-tracing-events/src/evm.rs
@@ -1,9 +1,9 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use codec::{Decode, Encode};
 use ethereum_types::{H160, H256, U256};
 use evm::ExitReason;
+use parity_scale_codec::{Decode, Encode};
 
 #[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
 pub struct Transfer {

--- a/primitives/bifrost/rpc/evm-tracing-events/src/gasometer.rs
+++ b/primitives/bifrost/rpc/evm-tracing-events/src/gasometer.rs
@@ -1,4 +1,4 @@
-use codec::{Decode, Encode};
+use parity_scale_codec::{Decode, Encode};
 
 #[derive(Debug, Default, Copy, Clone, Encode, Decode, PartialEq, Eq)]
 pub struct Snapshot {

--- a/primitives/bifrost/rpc/evm-tracing-events/src/lib.rs
+++ b/primitives/bifrost/rpc/evm-tracing-events/src/lib.rs
@@ -23,8 +23,8 @@ pub use self::evm::EvmEvent;
 pub use gasometer::GasometerEvent;
 pub use runtime::RuntimeEvent;
 
-use codec::{Decode, Encode};
 use ethereum_types::{H160, U256};
+use parity_scale_codec::{Decode, Encode};
 use sp_runtime_interface::pass_by::PassByCodec;
 
 environmental::environmental!(listener: dyn Listener + 'static);

--- a/primitives/bifrost/rpc/evm-tracing-events/src/runtime.rs
+++ b/primitives/bifrost/rpc/evm-tracing-events/src/runtime.rs
@@ -2,9 +2,9 @@ extern crate alloc;
 
 use super::Context;
 use alloc::vec::Vec;
-use codec::{Decode, Encode};
 use ethereum_types::{H160, H256, U256};
 pub use evm::{ExitError, ExitReason, ExitSucceed, Opcode};
+use parity_scale_codec::{Decode, Encode};
 
 #[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
 pub struct Stack {

--- a/primitives/bifrost/rpc/txpool/Cargo.toml
+++ b/primitives/bifrost/rpc/txpool/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "fp-rpc-txpool"
-authors = [ "bifrost-platform" ]
+authors = ["bifrost-platform"]
 edition = "2021"
-homepage = "https://thebifrost.io"
+homepage = "https://www.bifrostnetwork.com"
 license = "Apache-2.0"
 repository = "https://github.com/bifrost-platform/bifrost-frontier"
 version = "0.6.0"
 
 [dependencies]
-ethereum = { version = "0.14.0", default-features = false, features = [ "with-codec" ] }
+ethereum = { workspace = true, features = ["with-codec"] }
 
 # Substrate
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
+parity-scale-codec = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }
 sp-api = { workspace = true }
 sp-io = { workspace = true }
@@ -19,7 +19,7 @@ sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 
 [features]
-default = [ "std" ]
+default = ["std"]
 std = [
 	"ethereum/std",
 	"sp-api/std",

--- a/primitives/bifrost/rpc/txpool/src/lib.rs
+++ b/primitives/bifrost/rpc/txpool/src/lib.rs
@@ -3,8 +3,8 @@
 #![allow(clippy::unnecessary_mut_passed)]
 #![allow(clippy::too_many_arguments)]
 
-use codec::{Decode, Encode};
 pub use ethereum::{TransactionV0 as LegacyTransaction, TransactionV2 as Transaction};
+use parity_scale_codec::{Decode, Encode};
 use sp_runtime::{scale_info::TypeInfo, traits::Block as BlockT, RuntimeDebug};
 use sp_std::vec::Vec;
 


### PR DESCRIPTION
## Changes
- ethapi 관련 모듈에서 사용하는 crate 버전을 전부 workspace에 명시된 버전으로 사용하도록 변경

## TODO
- rollback substrate branch name