### PR TITLE
chore: increase maximum size allowed for solidity tuple type

### DIFF
--- a/precompiles/src/solidity/codec/native.rs
+++ b/precompiles/src/solidity/codec/native.rs
@@ -38,7 +38,7 @@ impl Codec for () {
 	}
 }
 
-#[impl_for_tuples(1, 18)]
+#[impl_for_tuples(1, 20)]
 impl Codec for Tuple {
 	fn has_static_size() -> bool {
 		for_tuples!(#( Tuple::has_static_size() )&*)


### PR DESCRIPTION
### Changes

- Increase the maximum length allowed for solidity tuple types (cc. https://github.com/bifrost-platform/bifrost-node/blob/main/precompiles/bfc-staking/src/types.rs#L47)